### PR TITLE
feat!: change Parser-API version args to represent just the major

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@asyncapi/protobuf-schema-parser": "^3.0.0",
         "@asyncapi/raml-dt-schema-parser": "^4.0.4",
         "parserv2": "npm:@asyncapi/parser@^2.1.0",
-        "parserv3": "npm:@asyncapi/parser@^2.2.0-next-major-spec.2"
+        "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
       },
       "devDependencies": {
         "@jest/types": "^29.0.2",
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.0.0-next-major-spec.6",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.6.tgz",
-      "integrity": "sha512-xYiXZetKiAZgZoh2q/sxt+Ceg8bLTK/WSCwtLvlH7JgnjpnOEtCDwKszijmmOJEYdGVSrj0OFXLPrg/dm4JANw==",
+      "version": "6.0.0-next-major-spec.7",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.7.tgz",
+      "integrity": "sha512-rorau4qa1rjlIz4vGy3MuzQKSyKyJWuRa3DbFKopixDCjnAOIScVDc/M6/T8X9Ay+GQhebcYrbiPT4JUvWbFAA==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -7778,9 +7778,9 @@
     },
     "node_modules/parserv3": {
       "name": "@asyncapi/parser",
-      "version": "2.2.0-next-major-spec.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.2.0-next-major-spec.2.tgz",
-      "integrity": "sha512-KkS+sPCHFFPZrFzzx4UGiYDrDfJI583AksLFg6QUKwr5Wjq8o7cIC3Hel2ptaRVv5x1nJz0o6QzFeY7VIWCc1g==",
+      "version": "3.0.0-next-major-spec.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.3.tgz",
+      "integrity": "sha512-LCrAQqJpGxraMyU2k1Nh1X6Q1dz7a/YhTRRFFrQHOEo+TUT/kRdoUkRDP++e58dO7h9MBN+/hZK5TaqE+/jQiw==",
       "dependencies": {
         "@asyncapi/specs": "^6.0.0-next-major-spec.6",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
@@ -9866,9 +9866,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.0.0-next-major-spec.6",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.6.tgz",
-      "integrity": "sha512-xYiXZetKiAZgZoh2q/sxt+Ceg8bLTK/WSCwtLvlH7JgnjpnOEtCDwKszijmmOJEYdGVSrj0OFXLPrg/dm4JANw==",
+      "version": "6.0.0-next-major-spec.7",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.7.tgz",
+      "integrity": "sha512-rorau4qa1rjlIz4vGy3MuzQKSyKyJWuRa3DbFKopixDCjnAOIScVDc/M6/T8X9Ay+GQhebcYrbiPT4JUvWbFAA==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }
@@ -15529,9 +15529,9 @@
       }
     },
     "parserv3": {
-      "version": "npm:@asyncapi/parser@2.2.0-next-major-spec.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.2.0-next-major-spec.2.tgz",
-      "integrity": "sha512-KkS+sPCHFFPZrFzzx4UGiYDrDfJI583AksLFg6QUKwr5Wjq8o7cIC3Hel2ptaRVv5x1nJz0o6QzFeY7VIWCc1g==",
+      "version": "npm:@asyncapi/parser@3.0.0-next-major-spec.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.3.tgz",
+      "integrity": "sha512-LCrAQqJpGxraMyU2k1Nh1X6Q1dz7a/YhTRRFFrQHOEo+TUT/kRdoUkRDP++e58dO7h9MBN+/hZK5TaqE+/jQiw==",
       "requires": {
         "@asyncapi/specs": "^6.0.0-next-major-spec.6",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@asyncapi/protobuf-schema-parser": "^3.0.0",
     "@asyncapi/raml-dt-schema-parser": "^4.0.4",
     "parserv2": "npm:@asyncapi/parser@^2.1.0",
-    "parserv3": "npm:@asyncapi/parser@^2.2.0-next-major-spec.2"
+    "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
   },
   "devDependencies": {
     "@jest/types": "^29.0.2",

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -7,26 +7,22 @@ import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV3 } f
 import type { DetailedAsyncAPI as DetailedAsyncAPIParserV2 } from 'parserv2/esm/types';
 import type { DetailedAsyncAPI as DetailedAsyncAPIParserV3 } from 'parserv3/esm/types';
 
-import { majorParserAPIVersion } from './utils';
-
 export type AsyncAPIDocument = AsyncAPIDocumentInterfaceParserV2 | AsyncAPIDocumentInterfaceParserV3;
 
-export function ConvertDocumentParserAPIVersion(doc: AsyncAPIDocument, toParserAPIVersion: string): AsyncAPIDocument {
+export function ConvertDocumentParserAPIVersion(doc: AsyncAPIDocument, toParserAPIMajorVersion: number): AsyncAPIDocument {
   if (!doc || !doc.json) return doc;
     
   const docParserAPI = doc.extensions().get('x-parser-api-version')?.value();
-  const docParserAPIMajorVersion: number = docParserAPI ? Number(String(docParserAPI).split('.')[0]) : 0;
-  const toMajorParserAPIVersion = majorParserAPIVersion(toParserAPIVersion);
+  const docParserAPIMajorVersion: number = docParserAPI || 0;
 
-  if (docParserAPIMajorVersion === toMajorParserAPIVersion) {
+  if (docParserAPIMajorVersion === toParserAPIMajorVersion) {
     return doc; // Nothing to do
   }
 
   const detailedAsyncAPI = doc.meta().asyncapi;
-  switch (toMajorParserAPIVersion) {
+  switch (toParserAPIMajorVersion) {
   case 1:
     return createAsyncAPIDocumentParserV2(detailedAsyncAPI as DetailedAsyncAPIParserV2);
-    // break;
   case 2:
     return createAsyncAPIDocumentParserV3(detailedAsyncAPI as DetailedAsyncAPIParserV3);
   default: 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,8 +9,6 @@ import { ProtoBuffSchemaParser } from '@asyncapi/protobuf-schema-parser';
 import type { ParserOptions as ParserOptionsParserV2 } from 'parserv2/esm/parser';
 import type { ParserOptions as ParserOptionsParserV3 } from 'parserv3/esm/parser';
 
-import { majorParserAPIVersion } from './utils';
-
 export type ParserOptions = ParserOptionsParserV2 | ParserOptionsParserV3;
 export type Options = {
   includeSchemaParsers?: boolean;
@@ -19,7 +17,7 @@ export type Options = {
 
 type Parser = ParserV2 | ParserV3;
 
-export function NewParser(parserAPIVersion: string, options?: Options): Parser {
+export function NewParser(parserAPIMajorVersion?: number, options?: Options): Parser {
   const parserOptions: ParserOptions = options?.parserOptions || {};
 
   // This is done globally instead of per version because latest versions of those schema parsers are still compatible with newer versions of the Parser-JS.
@@ -41,13 +39,11 @@ export function NewParser(parserAPIVersion: string, options?: Options): Parser {
       parserOptions.schemaParsers.push(...filteredDefaultSchemas as any);
     }
   }
-
-  const parserAPIMajorVersion = majorParserAPIVersion(parserAPIVersion); 
+ 
   switch (parserAPIMajorVersion) {
   case 1:
     return new ParserV2(parserOptions as ParserOptionsParserV2);
-  default:
-  case 0: // Using Parser v3 (latest atm) by default 
+  default: // default to latest version
   case 2:
     return new ParserV3(parserOptions as ParserOptionsParserV3);
   }   

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,0 @@
-export function majorParserAPIVersion(version: string): number {
-  if (!version) return 0;
-    
-  return Number(version.split('.')[0]);
-}

--- a/test/convert.spec.ts
+++ b/test/convert.spec.ts
@@ -9,11 +9,12 @@ describe('ConvertDocumentParserAPIVersion()', function() {
     const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
     const parsedDocParserV2 = (await new ParserV2().parse(doc)).document as AsyncAPIDocument;
 
-    // Even though the value here is '1' for Parser V3, we force to be '2.0.0' for this test to do the equality check later.
-    parsedDocParserV2['_json']['x-parser-api-version'] = '2.0.0';
+    // Even though the value here is 1 for Parser V3, we force to be 2 for this test to do the equality check later.
+    parsedDocParserV2['_json']['x-parser-api-version'] = 2;
 
     const parsedDocParserV3 = await new ParserV3().parse(doc);
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV2, '2.0.0');
+    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV2, 2);
+
     expect(convertedDoc).toEqual(parsedDocParserV3.document);
   });
 
@@ -21,17 +22,17 @@ describe('ConvertDocumentParserAPIVersion()', function() {
     const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
     const parsedDocParserV3 = (await new ParserV3().parse(doc)).document as AsyncAPIDocument;
 
-    // Even though the value here is '2.0.0' for Parser V3, we force to be 1 for this test to do the equality check later.
+    // Even though the value here is 2 for Parser V3, we force to be 1 for this test to do the equality check later.
     parsedDocParserV3['_json']['x-parser-api-version'] = 1;
 
     const parsedDocParserV2 = (await new ParserV2().parse(doc)).document;
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV3, '1.0.0');
+    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV3, 1);
     expect(convertedDoc).toEqual(parsedDocParserV2);
   });
   
   it('Skips converting if no document is passed', async function() {
     const doc = { } as AsyncAPIDocument;
-    const convertedDoc = ConvertDocumentParserAPIVersion(doc, '1.0.0');
+    const convertedDoc = ConvertDocumentParserAPIVersion(doc, 1);
     expect(convertedDoc).toEqual(doc);
   });
 });

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -18,13 +18,13 @@ const fakeSchemaParser = {
 
 describe('NewParser()', function() {
   it('Creates a Parser without options compatible with Parser-API v1 and caches it', async function() {
-    const parser = NewParser('1.0.0');
+    const parser = NewParser(1);
     expect(parser).toBeInstanceOf(ParserV2);
   });
 
   it('Creates a Parser with options compatible with Parser-API v1', async function() {
     const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
-    const parser = NewParser('1.0.0', options);
+    const parser = NewParser(1, options);
     
     expect(parser).toBeInstanceOf(ParserV2);
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
@@ -33,7 +33,7 @@ describe('NewParser()', function() {
   it('Creates a Parser with options including known Schema Parsers and do not overwrite those with Parser-API v1', async function() {
     const knownSchemaParser = AvroSchemaParser();
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
-    const parser = NewParser('1.0.0', options);
+    const parser = NewParser(1, options);
     
     expect(parser).toBeInstanceOf(ParserV2);
     expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);
@@ -43,13 +43,13 @@ describe('NewParser()', function() {
   });
 
   it('Creates a Parser without options compatible with Parser-API v2', async function() {
-    const parser = NewParser('2.0.0');
+    const parser = NewParser(2);
     expect(parser).toBeInstanceOf(ParserV3);
   });
 
   it('Creates a Parser with options compatible with Parser-API v2', async function() {
     const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
-    const parser = NewParser('2.0.0', options);
+    const parser = NewParser(2, options);
     expect(parser).toBeInstanceOf(ParserV3);
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
   });
@@ -57,7 +57,7 @@ describe('NewParser()', function() {
   it('Creates a Parser with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
     const knownSchemaParser = AvroSchemaParser();
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
-    const parser = NewParser('2.0.0', options);
+    const parser = NewParser(2, options);
     
     expect(parser).toBeInstanceOf(ParserV3);
     expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);
@@ -67,13 +67,13 @@ describe('NewParser()', function() {
   });
 
   it('Creates a Parser without options compatible with old Parser API (AKA v0)', async function() {
-    const parser = NewParser(''); // could be '0.0.0' as well
+    const parser = NewParser(); // could be '0.0.0' as well
     expect(parser).toBeInstanceOf(ParserV3); // Using Parser v3 (latest atm) by default
   });
 
   it('Creates a Parser with options compatible with old Parser API (AKA v0)', async function() {
     const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
-    const parser = NewParser('0.0.0', options); // could be empty string as well
+    const parser = NewParser(0, options); // could be empty string as well
     expect(parser).toBeInstanceOf(ParserV3);
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
   });
@@ -81,7 +81,7 @@ describe('NewParser()', function() {
   it('Creates a Parser with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
     const knownSchemaParser = AvroSchemaParser();
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
-    const parser = NewParser('0.0.0', options);
+    const parser = NewParser(0, options);
     
     expect(parser).toBeInstanceOf(ParserV3);
     expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);


### PR DESCRIPTION
**Description**

After the changes introduced in https://github.com/asyncapi/parser-js/pull/861, the value for the extension `` will always be just a number representing the major version. 
This PR adapts the signature of some methods to that change. Additionally, there is no longer a need to extract the major from the semver.