### PR TITLE
feat!: add support for parser API v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,9 @@
         "@asyncapi/openapi-schema-parser": "^3.0.4",
         "@asyncapi/protobuf-schema-parser": "^3.0.0",
         "@asyncapi/raml-dt-schema-parser": "^4.0.4",
-        "parserv2": "npm:@asyncapi/parser@^2.1.0",
-        "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
+        "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
+        "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
+        "parserapiv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.10"
       },
       "devDependencies": {
         "@jest/types": "^29.0.2",
@@ -189,9 +190,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.0.0-next-major-spec.7",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.7.tgz",
-      "integrity": "sha512-rorau4qa1rjlIz4vGy3MuzQKSyKyJWuRa3DbFKopixDCjnAOIScVDc/M6/T8X9Ay+GQhebcYrbiPT4JUvWbFAA==",
+      "version": "6.0.0-next-major-spec.13",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.13.tgz",
+      "integrity": "sha512-mnGllHVaUscCHaDnYfLGo84KK81NcTmevVFQP94RusKM2SvtYkbBuC0nwQ6ie/PAEHQy+kn2PjrJlfwwm7VgEQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -7715,18 +7716,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parserv2": {
+    "node_modules/parserapiv1": {
       "name": "@asyncapi/parser",
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
-      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
+      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
       "dependencies": {
         "@asyncapi/specs": "^5.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json": "^3.20.2",
+        "@stoplight/json-ref-readers": "^1.2.2",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
         "@stoplight/spectral-functions": "^1.7.2",
         "@stoplight/spectral-parsers": "^1.0.2",
+        "@stoplight/spectral-ref-resolver": "^1.0.3",
+        "@stoplight/types": "^13.12.0",
         "@types/json-schema": "^7.0.11",
         "@types/urijs": "^1.19.19",
         "ajv": "^8.11.0",
@@ -7740,7 +7745,7 @@
         "webapi-parser": "^0.5.0"
       }
     },
-    "node_modules/parserv2/node_modules/@asyncapi/specs": {
+    "node_modules/parserapiv1/node_modules/@asyncapi/specs": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
       "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
@@ -7748,7 +7753,7 @@
         "@types/json-schema": "^7.0.11"
       }
     },
-    "node_modules/parserv2/node_modules/ajv": {
+    "node_modules/parserapiv1/node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
@@ -7763,7 +7768,7 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/parserv2/node_modules/ajv-errors": {
+    "node_modules/parserapiv1/node_modules/ajv-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
       "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
@@ -7771,18 +7776,18 @@
         "ajv": "^8.0.1"
       }
     },
-    "node_modules/parserv2/node_modules/json-schema-traverse": {
+    "node_modules/parserapiv1/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "node_modules/parserv3": {
+    "node_modules/parserapiv2": {
       "name": "@asyncapi/parser",
-      "version": "3.0.0-next-major-spec.3",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.3.tgz",
-      "integrity": "sha512-LCrAQqJpGxraMyU2k1Nh1X6Q1dz7a/YhTRRFFrQHOEo+TUT/kRdoUkRDP++e58dO7h9MBN+/hZK5TaqE+/jQiw==",
+      "version": "3.0.0-next-major-spec.8",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.8.tgz",
+      "integrity": "sha512-d8ebYM08BCsx3Q4AeLke6naU/NrcAXFEVpS6b3EWcKRdUDce+v0X5k9aDH+YXWCaQApEF28UzcxhlSOJvhIFgQ==",
       "dependencies": {
-        "@asyncapi/specs": "^6.0.0-next-major-spec.6",
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
@@ -7801,7 +7806,7 @@
         "webapi-parser": "^0.5.0"
       }
     },
-    "node_modules/parserv3/node_modules/ajv": {
+    "node_modules/parserapiv2/node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
@@ -7816,7 +7821,7 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/parserv3/node_modules/ajv-errors": {
+    "node_modules/parserapiv2/node_modules/ajv-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
       "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
@@ -7824,7 +7829,60 @@
         "ajv": "^8.0.1"
       }
     },
-    "node_modules/parserv3/node_modules/json-schema-traverse": {
+    "node_modules/parserapiv2/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/parserapiv3": {
+      "name": "@asyncapi/parser",
+      "version": "3.0.0-next-major-spec.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.10.tgz",
+      "integrity": "sha512-z3kdevI4s7mz4+fElG/fqYtI7Kpuc7TAkrCfABTl6/h75PO0xI8bnz0IfT5xk5sSqSuitupMlfw1CPfYFfFo0g==",
+      "dependencies": {
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/parserapiv3/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/parserapiv3/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/parserapiv3/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
@@ -9866,9 +9924,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.0.0-next-major-spec.7",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.7.tgz",
-      "integrity": "sha512-rorau4qa1rjlIz4vGy3MuzQKSyKyJWuRa3DbFKopixDCjnAOIScVDc/M6/T8X9Ay+GQhebcYrbiPT4JUvWbFAA==",
+      "version": "6.0.0-next-major-spec.13",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.13.tgz",
+      "integrity": "sha512-mnGllHVaUscCHaDnYfLGo84KK81NcTmevVFQP94RusKM2SvtYkbBuC0nwQ6ie/PAEHQy+kn2PjrJlfwwm7VgEQ==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }
@@ -15472,17 +15530,21 @@
         "lines-and-columns": "^1.1.6"
       }
     },
-    "parserv2": {
-      "version": "npm:@asyncapi/parser@2.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
-      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+    "parserapiv1": {
+      "version": "npm:@asyncapi/parser@2.1.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
+      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
       "requires": {
         "@asyncapi/specs": "^5.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json": "^3.20.2",
+        "@stoplight/json-ref-readers": "^1.2.2",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
         "@stoplight/spectral-functions": "^1.7.2",
         "@stoplight/spectral-parsers": "^1.0.2",
+        "@stoplight/spectral-ref-resolver": "^1.0.3",
+        "@stoplight/types": "^13.12.0",
         "@types/json-schema": "^7.0.11",
         "@types/urijs": "^1.19.19",
         "ajv": "^8.11.0",
@@ -15528,12 +15590,60 @@
         }
       }
     },
-    "parserv3": {
-      "version": "npm:@asyncapi/parser@3.0.0-next-major-spec.3",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.3.tgz",
-      "integrity": "sha512-LCrAQqJpGxraMyU2k1Nh1X6Q1dz7a/YhTRRFFrQHOEo+TUT/kRdoUkRDP++e58dO7h9MBN+/hZK5TaqE+/jQiw==",
+    "parserapiv2": {
+      "version": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.8.tgz",
+      "integrity": "sha512-d8ebYM08BCsx3Q4AeLke6naU/NrcAXFEVpS6b3EWcKRdUDce+v0X5k9aDH+YXWCaQApEF28UzcxhlSOJvhIFgQ==",
       "requires": {
-        "@asyncapi/specs": "^6.0.0-next-major-spec.6",
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "parserapiv3": {
+      "version": "npm:@asyncapi/parser@3.0.0-next-major-spec.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.10.tgz",
+      "integrity": "sha512-z3kdevI4s7mz4+fElG/fqYtI7Kpuc7TAkrCfABTl6/h75PO0xI8bnz0IfT5xk5sSqSuitupMlfw1CPfYFfFo0g==",
+      "requires": {
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
     "@asyncapi/openapi-schema-parser": "^3.0.4",
     "@asyncapi/protobuf-schema-parser": "^3.0.0",
     "@asyncapi/raml-dt-schema-parser": "^4.0.4",
-    "parserv2": "npm:@asyncapi/parser@^2.1.0",
-    "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
+    "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
+    "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
+    "parserapiv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.10"
   },
   "devDependencies": {
     "@jest/types": "^29.0.2",

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,13 +1,16 @@
-import { createAsyncAPIDocument as createAsyncAPIDocumentParserV2 } from 'parserv2';
-import { createAsyncAPIDocument as createAsyncAPIDocumentParserV3 } from 'parserv3';
+import { createAsyncAPIDocument as createAsyncAPIDocumentParserV1 } from 'parserapiv1';
+import { createAsyncAPIDocument as createAsyncAPIDocumentParserV2 } from 'parserapiv2';
+import { createAsyncAPIDocument as createAsyncAPIDocumentParserV3 } from 'parserapiv3';
 
-import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV2 } from 'parserv2';
-import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV3 } from 'parserv3';
+import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV1 } from 'parserapiv1';
+import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV2 } from 'parserapiv2';
+import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV3 } from 'parserapiv3';
 
-import type { DetailedAsyncAPI as DetailedAsyncAPIParserV2 } from 'parserv2/esm/types';
-import type { DetailedAsyncAPI as DetailedAsyncAPIParserV3 } from 'parserv3/esm/types';
+import type { DetailedAsyncAPI as DetailedAsyncAPIParserV1 } from 'parserapiv1/esm/types';
+import type { DetailedAsyncAPI as DetailedAsyncAPIParserV2 } from 'parserapiv2/esm/types';
+import type { DetailedAsyncAPI as DetailedAsyncAPIParserV3 } from 'parserapiv3/esm/types';
 
-export type AsyncAPIDocument = AsyncAPIDocumentInterfaceParserV2 | AsyncAPIDocumentInterfaceParserV3;
+export type AsyncAPIDocument = AsyncAPIDocumentInterfaceParserV1 | AsyncAPIDocumentInterfaceParserV2 | AsyncAPIDocumentInterfaceParserV3;
 
 export function ConvertDocumentParserAPIVersion(doc: AsyncAPIDocument, toParserAPIMajorVersion: number): AsyncAPIDocument {
   if (!doc || !doc.json) return doc;
@@ -22,8 +25,10 @@ export function ConvertDocumentParserAPIVersion(doc: AsyncAPIDocument, toParserA
   const detailedAsyncAPI = doc.meta().asyncapi;
   switch (toParserAPIMajorVersion) {
   case 1:
-    return createAsyncAPIDocumentParserV2(detailedAsyncAPI as DetailedAsyncAPIParserV2);
+    return createAsyncAPIDocumentParserV1(detailedAsyncAPI as DetailedAsyncAPIParserV1);
   case 2:
+    return createAsyncAPIDocumentParserV2(detailedAsyncAPI as DetailedAsyncAPIParserV2);
+  case 3:
     return createAsyncAPIDocumentParserV3(detailedAsyncAPI as DetailedAsyncAPIParserV3);
   default: 
     return doc;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,21 +1,23 @@
-import { Parser as ParserV2 } from 'parserv2';
-import { Parser as ParserV3 } from 'parserv3';
+import { Parser as ParserV1 } from 'parserapiv1';
+import { Parser as ParserV2 } from 'parserapiv2';
+import { Parser as ParserV3 } from 'parserapiv3';
 
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
 import { OpenAPISchemaParser } from '@asyncapi/openapi-schema-parser';
 import { RamlDTSchemaParser } from '@asyncapi/raml-dt-schema-parser';
 import { ProtoBuffSchemaParser } from '@asyncapi/protobuf-schema-parser';
 
-import type { ParserOptions as ParserOptionsParserV2 } from 'parserv2/esm/parser';
-import type { ParserOptions as ParserOptionsParserV3 } from 'parserv3/esm/parser';
+import type { ParserOptions as ParserOptionsParserV1 } from 'parserapiv1/esm/parser';
+import type { ParserOptions as ParserOptionsParserV2 } from 'parserapiv2/esm/parser';
+import type { ParserOptions as ParserOptionsParserV3 } from 'parserapiv3/esm/parser';
 
-export type ParserOptions = ParserOptionsParserV2 | ParserOptionsParserV3;
+export type ParserOptions = ParserOptionsParserV1 | ParserOptionsParserV2 | ParserOptionsParserV3;
 export type Options = {
   includeSchemaParsers?: boolean;
   parserOptions?: ParserOptions;
 }
 
-type Parser = ParserV2 | ParserV3;
+type Parser = ParserV1 | ParserV2 | ParserV3;
 
 export function NewParser(parserAPIMajorVersion?: number, options?: Options): Parser {
   const parserOptions: ParserOptions = options?.parserOptions || {};
@@ -42,9 +44,11 @@ export function NewParser(parserAPIMajorVersion?: number, options?: Options): Pa
  
   switch (parserAPIMajorVersion) {
   case 1:
+    return new ParserV1(parserOptions as ParserOptionsParserV1);
+  case 2:
     return new ParserV2(parserOptions as ParserOptionsParserV2);
   default: // default to latest version
-  case 2:
+  case 3:
     return new ParserV3(parserOptions as ParserOptionsParserV3);
   }   
 }

--- a/test/convert.spec.ts
+++ b/test/convert.spec.ts
@@ -1,33 +1,58 @@
 
-import { Parser as ParserV2 } from 'parserv2';
-import { Parser as ParserV3 } from 'parserv3';
+import { Parser as ParserV1 } from 'parserapiv1';
+import { Parser as ParserV2 } from 'parserapiv2';
+import { Parser as ParserV3 } from 'parserapiv3';
 
 import { AsyncAPIDocument, ConvertDocumentParserAPIVersion } from '../src/convert';
 
 describe('ConvertDocumentParserAPIVersion()', function() {
   it('Converts from Parser-API v1 to Parser-API v2', async function() {
     const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
-    const parsedDocParserV2 = (await new ParserV2().parse(doc)).document as AsyncAPIDocument;
+    const parsedDocParserV1 = (await new ParserV1().parse(doc)).document as AsyncAPIDocument;
 
-    // Even though the value here is 1 for Parser V3, we force to be 2 for this test to do the equality check later.
-    parsedDocParserV2['_json']['x-parser-api-version'] = 2;
+    // Even though the value here is 1 for Parser V1, we force to be 2 for this test to do the equality check later.
+    parsedDocParserV1['_json']['x-parser-api-version'] = 2;
 
-    const parsedDocParserV3 = await new ParserV3().parse(doc);
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV2, 2);
+    const parsedDocParserV2 = await new ParserV2().parse(doc);
+    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV1, 2);
 
-    expect(convertedDoc).toEqual(parsedDocParserV3.document);
+    expect(convertedDoc).toEqual(parsedDocParserV2.document);
   });
 
   it('Converts from Parser-API v2 to Parser-API v1', async function() {
     const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
+    const parsedDocParserV2 = (await new ParserV2().parse(doc)).document as AsyncAPIDocument;
+
+    // Even though the value here is 2 for Parser V2, we force to be 1 for this test to do the equality check later.
+    parsedDocParserV2['_json']['x-parser-api-version'] = 1;
+
+    const parsedDocParserV1 = (await new ParserV1().parse(doc)).document;
+    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV2, 1);
+    expect(convertedDoc).toEqual(parsedDocParserV1);
+  });
+
+  it('Converts from Parser-API v3 to Parser-API v2', async function() {
+    const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
     const parsedDocParserV3 = (await new ParserV3().parse(doc)).document as AsyncAPIDocument;
 
-    // Even though the value here is 2 for Parser V3, we force to be 1 for this test to do the equality check later.
-    parsedDocParserV3['_json']['x-parser-api-version'] = 1;
+    // Even though the value here is 3 for Parser V3, we force to be 2 for this test to do the equality check later.
+    parsedDocParserV3['_json']['x-parser-api-version'] = 2;
 
     const parsedDocParserV2 = (await new ParserV2().parse(doc)).document;
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV3, 1);
+    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV3, 2);
     expect(convertedDoc).toEqual(parsedDocParserV2);
+  });
+
+  it('Converts from Parser-API v3 to Parser-API v1', async function() {
+    const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
+    const parsedDocParserV3 = (await new ParserV3().parse(doc)).document as AsyncAPIDocument;
+
+    // Even though the value here is 3 for Parser V3, we force to be 1 for this test to do the equality check later.
+    parsedDocParserV3['_json']['x-parser-api-version'] = 1;
+
+    const parsedDocParserV1 = (await new ParserV1().parse(doc)).document;
+    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV3, 1);
+    expect(convertedDoc).toEqual(parsedDocParserV1);
   });
   
   it('Skips converting if no document is passed', async function() {

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -55,6 +55,13 @@ describe('NewParser()', function() {
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
   });
 
+  it('Creates a Parser with options compatible with Parser-API v3', async function() {
+    const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
+    const parser = NewParser(3, options);
+    expect(parser).toBeInstanceOf(ParserV3);
+    expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
+  });
+
   it('Creates a Parser 2 with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
     const knownSchemaParser = AvroSchemaParser();
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -1,6 +1,7 @@
 
-import { Parser as ParserV2 } from 'parserv2';
-import { Parser as ParserV3 } from 'parserv3';
+import { Parser as ParserV1 } from 'parserapiv1';
+import { Parser as ParserV2 } from 'parserapiv2';
+import { Parser as ParserV3 } from 'parserapiv3';
 
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
 import { OpenAPISchemaParser } from '@asyncapi/openapi-schema-parser';
@@ -19,14 +20,14 @@ const fakeSchemaParser = {
 describe('NewParser()', function() {
   it('Creates a Parser without options compatible with Parser-API v1 and caches it', async function() {
     const parser = NewParser(1);
-    expect(parser).toBeInstanceOf(ParserV2);
+    expect(parser).toBeInstanceOf(ParserV1);
   });
 
   it('Creates a Parser with options compatible with Parser-API v1', async function() {
     const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
     const parser = NewParser(1, options);
     
-    expect(parser).toBeInstanceOf(ParserV2);
+    expect(parser).toBeInstanceOf(ParserV1);
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
   });
 
@@ -35,7 +36,7 @@ describe('NewParser()', function() {
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
     const parser = NewParser(1, options);
     
-    expect(parser).toBeInstanceOf(ParserV2);
+    expect(parser).toBeInstanceOf(ParserV1);
     expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);
     expect(parser.parserRegistry.get(OpenAPISchemaParser().getMimeTypes()[0])).toEqual(OpenAPISchemaParser());
     expect(parser.parserRegistry.get(RamlDTSchemaParser().getMimeTypes()[0])).toEqual(RamlDTSchemaParser());
@@ -44,22 +45,22 @@ describe('NewParser()', function() {
 
   it('Creates a Parser without options compatible with Parser-API v2', async function() {
     const parser = NewParser(2);
-    expect(parser).toBeInstanceOf(ParserV3);
+    expect(parser).toBeInstanceOf(ParserV2);
   });
 
   it('Creates a Parser with options compatible with Parser-API v2', async function() {
     const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
     const parser = NewParser(2, options);
-    expect(parser).toBeInstanceOf(ParserV3);
+    expect(parser).toBeInstanceOf(ParserV2);
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
   });
 
-  it('Creates a Parser with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
+  it('Creates a Parser 2 with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
     const knownSchemaParser = AvroSchemaParser();
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
     const parser = NewParser(2, options);
     
-    expect(parser).toBeInstanceOf(ParserV3);
+    expect(parser).toBeInstanceOf(ParserV2);
     expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);
     expect(parser.parserRegistry.get(OpenAPISchemaParser().getMimeTypes()[0])).toEqual(OpenAPISchemaParser());
     expect(parser.parserRegistry.get(RamlDTSchemaParser().getMimeTypes()[0])).toEqual(RamlDTSchemaParser());
@@ -78,7 +79,7 @@ describe('NewParser()', function() {
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
   });
 
-  it('Creates a Parser with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
+  it('Creates a Parser 0 with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
     const knownSchemaParser = AvroSchemaParser();
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
     const parser = NewParser(0, options);


### PR DESCRIPTION
**Description**
This PR adds support for parser API v3, as of `@asyncapi/parser@3.0.0-next-major-spec.9`. This means that parser API v2 support stops at `@asyncapi/parser@3.0.0-next-major-spec.8`.

Here are the changes introduced:
- Updated the dependency names so they match each parser API i.e. v1 -> v3
- Added tests to the converter to check that v3 can downgrade to v2 and v1
- Adapted the tests for parser to check parser API v3 works as expected
- Hardcoded parser API v2 to `@asyncapi/parser@3.0.0-next-major-spec.8` as `9` introduces parser API v3
- Added parser API v3 dependency
- Adapted the implementation to to support parser API v3

**Related issue(s)**
Related to https://github.com/asyncapi/html-template/issues/456