### PR TITLE
fix: update parser-js to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@asyncapi/raml-dt-schema-parser": "^4.0.4",
         "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
         "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
-        "parserapiv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.10"
+        "parserapiv3": "npm:@asyncapi/parser@^3.0.1"
       },
       "devDependencies": {
         "@jest/types": "^29.0.2",
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.0.0-next-major-spec.13",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.13.tgz",
-      "integrity": "sha512-mnGllHVaUscCHaDnYfLGo84KK81NcTmevVFQP94RusKM2SvtYkbBuC0nwQ6ie/PAEHQy+kn2PjrJlfwwm7VgEQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.0.tgz",
+      "integrity": "sha512-5uf/Rg6pavZHx7rVIkP0TP/icIahJCuHgmY1rdtkrWxHZMXbASDDV3DlTUaonbsUeemwchoqljmrTd1O1xqvxg==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -7836,16 +7836,20 @@
     },
     "node_modules/parserapiv3": {
       "name": "@asyncapi/parser",
-      "version": "3.0.0-next-major-spec.10",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.10.tgz",
-      "integrity": "sha512-z3kdevI4s7mz4+fElG/fqYtI7Kpuc7TAkrCfABTl6/h75PO0xI8bnz0IfT5xk5sSqSuitupMlfw1CPfYFfFo0g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.1.tgz",
+      "integrity": "sha512-LtRVjbswpqW7TlSqnGVdFm1da3DV1sqQz07ZG6xqzpR2A2pkn16+5Fk+OhuAggZ0atXNLSYfYSuKp8t3iKvrKA==",
       "dependencies": {
-        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@asyncapi/specs": "^6.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json": "^3.20.2",
+        "@stoplight/json-ref-readers": "^1.2.2",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
         "@stoplight/spectral-functions": "^1.7.2",
         "@stoplight/spectral-parsers": "^1.0.2",
+        "@stoplight/spectral-ref-resolver": "^1.0.3",
+        "@stoplight/types": "^13.12.0",
         "@types/json-schema": "^7.0.11",
         "@types/urijs": "^1.19.19",
         "ajv": "^8.11.0",
@@ -7854,9 +7858,7 @@
         "avsc": "^5.7.5",
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7",
-        "ramldt2jsonschema": "^1.2.3",
-        "webapi-parser": "^0.5.0"
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/parserapiv3/node_modules/ajv": {
@@ -9924,9 +9926,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "6.0.0-next-major-spec.13",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.13.tgz",
-      "integrity": "sha512-mnGllHVaUscCHaDnYfLGo84KK81NcTmevVFQP94RusKM2SvtYkbBuC0nwQ6ie/PAEHQy+kn2PjrJlfwwm7VgEQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.2.0.tgz",
+      "integrity": "sha512-5uf/Rg6pavZHx7rVIkP0TP/icIahJCuHgmY1rdtkrWxHZMXbASDDV3DlTUaonbsUeemwchoqljmrTd1O1xqvxg==",
       "requires": {
         "@types/json-schema": "^7.0.11"
       }
@@ -15639,16 +15641,20 @@
       }
     },
     "parserapiv3": {
-      "version": "npm:@asyncapi/parser@3.0.0-next-major-spec.10",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.10.tgz",
-      "integrity": "sha512-z3kdevI4s7mz4+fElG/fqYtI7Kpuc7TAkrCfABTl6/h75PO0xI8bnz0IfT5xk5sSqSuitupMlfw1CPfYFfFo0g==",
+      "version": "npm:@asyncapi/parser@3.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.1.tgz",
+      "integrity": "sha512-LtRVjbswpqW7TlSqnGVdFm1da3DV1sqQz07ZG6xqzpR2A2pkn16+5Fk+OhuAggZ0atXNLSYfYSuKp8t3iKvrKA==",
       "requires": {
-        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@asyncapi/specs": "^6.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json": "^3.20.2",
+        "@stoplight/json-ref-readers": "^1.2.2",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
         "@stoplight/spectral-functions": "^1.7.2",
         "@stoplight/spectral-parsers": "^1.0.2",
+        "@stoplight/spectral-ref-resolver": "^1.0.3",
+        "@stoplight/types": "^13.12.0",
         "@types/json-schema": "^7.0.11",
         "@types/urijs": "^1.19.19",
         "ajv": "^8.11.0",
@@ -15657,9 +15663,7 @@
         "avsc": "^5.7.5",
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7",
-        "ramldt2jsonschema": "^1.2.3",
-        "webapi-parser": "^0.5.0"
+        "node-fetch": "2.6.7"
       },
       "dependencies": {
         "ajv": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@asyncapi/raml-dt-schema-parser": "^4.0.4",
     "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
     "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
-    "parserapiv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.10"
+    "parserapiv3": "npm:@asyncapi/parser@^3.0.1"
   },
   "devDependencies": {
     "@jest/types": "^29.0.2",


### PR DESCRIPTION
**Description**

This PR updates `parserapiv3` dependency to the recently released Parser-JS (v3.0.1 atm).